### PR TITLE
Convert singly linked list to doubly linked list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 # cursor_agent_test
 
-## Linked List Example
+## Doubly Linked List Example
 
-This repository contains a simple implementation of a singly linked list in Python.
+This repository contains a simple implementation of a doubly linked list in Python.
 
 ### Files
 
-- `linked_list_example.py` - Complete linked list implementation with examples
+- `linked_list_example.py` - Complete doubly linked list implementation with examples
 
 ### Features
 
-The linked list implementation includes:
+The doubly linked list implementation includes:
 
-- **Node Class**: Basic building block with data and next pointer
-- **LinkedList Class**: Full implementation with the following operations:
-  - `append(data)` - Add element to the end
-  - `prepend(data)` - Add element to the beginning
+- **Node Class**: Building block with data, a `next` pointer, and a `prev` pointer
+- **LinkedList Class**: Full implementation with a `head` and `tail` pointer, supporting the following operations:
+  - `append(data)` - Add element to the end (O(1))
+  - `prepend(data)` - Add element to the beginning (O(1))
   - `insert(index, data)` - Insert element at specific position
   - `delete(data)` - Remove first occurrence of data
   - `delete_at_index(index)` - Remove element at specific position
@@ -23,7 +23,8 @@ The linked list implementation includes:
   - `get(index)` - Get element at specific position
   - `is_empty()` - Check if list is empty
   - `length()` - Get number of elements
-  - `display()` - Show visual representation
+  - `display()` - Show visual representation from head to tail (e.g. `None <-> 1 <-> 2 <-> None`)
+  - `display_reverse()` - Show visual representation from tail to head
   - `reverse()` - Reverse the list in place
 
 ### Running the Example
@@ -34,19 +35,20 @@ python3 linked_list_example.py
 
 ### Example Output
 
-The script demonstrates all linked list operations with clear output showing:
+The script demonstrates all doubly linked list operations with clear output showing:
 1. Creating and checking empty list
 2. Adding elements (append/prepend)
 3. Inserting at specific positions
 4. Finding elements
 5. Deleting elements
-6. Reversing the list
-7. Edge case handling
+6. Traversing in reverse (tail to head)
+7. Reversing the list
+8. Edge case handling
 
 ### Key Concepts Demonstrated
 
-- **Node Structure**: Each node contains data and a reference to the next node
-- **Dynamic Memory**: Nodes are created and linked dynamically
-- **Traversal**: Walking through the list using the next pointers
-- **Insertion/Deletion**: Manipulating pointers to add/remove nodes
+- **Node Structure**: Each node contains data and references to both the next and previous nodes
+- **Bidirectional Traversal**: The list can be traversed in both directions using `next` and `prev` pointers
+- **Tail Pointer**: A dedicated `tail` pointer enables O(1) append and reverse traversal
+- **Insertion/Deletion**: Manipulating both `prev` and `next` pointers to add/remove nodes
 - **Edge Cases**: Handling empty lists and single-element lists

--- a/linked_list_example.py
+++ b/linked_list_example.py
@@ -1,222 +1,248 @@
 from typing import Optional, Any
 
 class Node:
-    """A node in a linked list containing data and a reference to the next node."""
-    
+    """A node in a doubly linked list containing data and references to the next and previous nodes."""
+
     def __init__(self, data: Any):
         self.data = data
         self.next: Optional['Node'] = None
+        self.prev: Optional['Node'] = None
 
 class LinkedList:
-    """A simple implementation of a singly linked list."""
-    
+    """A simple implementation of a doubly linked list."""
+
     def __init__(self):
         self.head = None
+        self.tail = None
         self.size = 0
-    
+
     def append(self, data):
         """Add a new node with the given data to the end of the list."""
         new_node = Node(data)
-        
+
         if not self.head:
             self.head = new_node
+            self.tail = new_node
         else:
-            current = self.head
-            while current.next:
-                current = current.next
-            current.next = new_node
-        
+            new_node.prev = self.tail
+            self.tail.next = new_node
+            self.tail = new_node
+
         self.size += 1
-    
+
     def prepend(self, data):
         """Add a new node with the given data to the beginning of the list."""
         new_node = Node(data)
-        new_node.next = self.head
-        self.head = new_node
+
+        if not self.head:
+            self.head = new_node
+            self.tail = new_node
+        else:
+            new_node.next = self.head
+            self.head.prev = new_node
+            self.head = new_node
+
         self.size += 1
-    
+
     def insert(self, index, data):
         """Insert a new node with the given data at the specified index."""
         if index < 0 or index > self.size:
             raise IndexError("Index out of range")
-        
+
         if index == 0:
             self.prepend(data)
             return
-        
+
+        if index == self.size:
+            self.append(data)
+            return
+
         new_node = Node(data)
         current = self.head
-        
+
         for i in range(index - 1):
             current = current.next
-        
+
         new_node.next = current.next
+        new_node.prev = current
+        if current.next:
+            current.next.prev = new_node
         current.next = new_node
         self.size += 1
-    
+
     def delete(self, data):
         """Delete the first occurrence of the given data from the list."""
-        if not self.head:
-            return False
-        
-        if self.head.data == data:
-            self.head = self.head.next
-            self.size -= 1
-            return True
-        
         current = self.head
-        while current.next:
-            if current.next.data == data:
-                current.next = current.next.next
-                self.size -= 1
+
+        while current:
+            if current.data == data:
+                self._unlink(current)
                 return True
             current = current.next
-        
+
         return False
-    
+
     def delete_at_index(self, index):
         """Delete the node at the specified index."""
         if index < 0 or index >= self.size:
             raise IndexError("Index out of range")
-        
-        if index == 0 and self.head:
-            self.head = self.head.next
-            self.size -= 1
-            return
-        
+
         current = self.head
-        for i in range(index - 1):
-            if current:
-                current = current.next
-        
-        if current and current.next:
-            current.next = current.next.next
+        for i in range(index):
+            current = current.next
+
+        self._unlink(current)
+
+    def _unlink(self, node):
+        """Remove a node from the list by updating its neighbours' pointers."""
+        if node.prev:
+            node.prev.next = node.next
+        else:
+            self.head = node.next
+
+        if node.next:
+            node.next.prev = node.prev
+        else:
+            self.tail = node.prev
+
         self.size -= 1
-    
+
     def find(self, data):
         """Find the index of the first occurrence of the given data."""
         current = self.head
         index = 0
-        
+
         while current:
             if current.data == data:
                 return index
             current = current.next
             index += 1
-        
+
         return -1  # Not found
-    
+
     def get(self, index):
         """Get the data at the specified index."""
         if index < 0 or index >= self.size:
             raise IndexError("Index out of range")
-        
+
         current = self.head
         for i in range(index):
-            if current:
-                current = current.next
-        
-        if current:
-            return current.data
-        raise IndexError("Index out of range")
-    
+            current = current.next
+
+        return current.data
+
     def is_empty(self):
         """Check if the list is empty."""
         return self.head is None
-    
+
     def length(self):
         """Get the number of nodes in the list."""
         return self.size
-    
+
     def display(self):
-        """Return a string representation of the list."""
+        """Return a string representation of the list from head to tail."""
         if not self.head:
             return "Empty list"
-        
+
         elements = []
         current = self.head
         while current:
             elements.append(str(current.data))
             current = current.next
-        
-        return " -> ".join(elements) + " -> None"
-    
-    def reverse(self):
-        """Reverse the linked list in place."""
-        prev = None
-        current = self.head
-        
+
+        return "None <-> " + " <-> ".join(elements) + " <-> None"
+
+    def display_reverse(self):
+        """Return a string representation of the list from tail to head."""
+        if not self.tail:
+            return "Empty list"
+
+        elements = []
+        current = self.tail
         while current:
-            next_node = current.next
-            current.next = prev
-            prev = current
-            current = next_node
-        
-        self.head = prev
+            elements.append(str(current.data))
+            current = current.prev
+
+        return "None <-> " + " <-> ".join(elements) + " <-> None"
+
+    def reverse(self):
+        """Reverse the doubly linked list in place."""
+        current = self.head
+
+        while current:
+            current.prev, current.next = current.next, current.prev
+            current = current.prev  # Move to the next node (now stored in prev)
+
+        self.head, self.tail = self.tail, self.head
 
 
 def main():
-    """Demonstrate the linked list operations with examples."""
-    print("=== Linked List Example ===\n")
-    
+    """Demonstrate the doubly linked list operations with examples."""
+    print("=== Doubly Linked List Example ===\n")
+
     # Create a new linked list
     ll = LinkedList()
-    
-    print("1. Creating an empty linked list:")
+
+    print("1. Creating an empty doubly linked list:")
     print(f"   List: {ll.display()}")
     print(f"   Is empty: {ll.is_empty()}")
     print(f"   Length: {ll.length()}\n")
-    
+
     # Add elements to the list
     print("2. Adding elements:")
     ll.append(10)
     print(f"   After appending 10: {ll.display()}")
-    
+
     ll.append(20)
     ll.append(30)
     print(f"   After appending 20, 30: {ll.display()}")
-    
+
     ll.prepend(5)
     print(f"   After prepending 5: {ll.display()}")
     print(f"   Length: {ll.length()}\n")
-    
+
     # Insert at specific position
     print("3. Inserting at specific positions:")
     ll.insert(2, 15)
     print(f"   After inserting 15 at index 2: {ll.display()}")
-    
+
     ll.insert(0, 1)
     print(f"   After inserting 1 at index 0: {ll.display()}\n")
-    
+
     # Find elements
     print("4. Finding elements:")
     print(f"   Index of 15: {ll.find(15)}")
     print(f"   Index of 100 (not in list): {ll.find(100)}")
     print(f"   Element at index 3: {ll.get(3)}\n")
-    
+
     # Delete elements
     print("5. Deleting elements:")
     print(f"   Before deletion: {ll.display()}")
-    
+
     ll.delete(15)
     print(f"   After deleting 15: {ll.display()}")
-    
+
     ll.delete_at_index(0)
     print(f"   After deleting element at index 0: {ll.display()}")
     print(f"   Length: {ll.length()}\n")
-    
+
+    # Traverse in reverse using display_reverse
+    print("6. Traversing in reverse (tail to head):")
+    print(f"   Forward:  {ll.display()}")
+    print(f"   Backward: {ll.display_reverse()}\n")
+
     # Reverse the list
-    print("6. Reversing the list:")
+    print("7. Reversing the list:")
     print(f"   Before reverse: {ll.display()}")
     ll.reverse()
     print(f"   After reverse: {ll.display()}\n")
-    
+
     # Edge cases
-    print("7. Testing edge cases:")
+    print("8. Testing edge cases:")
     empty_list = LinkedList()
     print(f"   Empty list: {empty_list.display()}")
     print(f"   Deleting from empty list: {empty_list.delete(10)}")
-    
+
     single_item_list = LinkedList()
     single_item_list.append(42)
     print(f"   Single item list: {single_item_list.display()}")


### PR DESCRIPTION
- Node class now has both next and prev pointers
- LinkedList maintains a tail pointer for O(1) append
- All insert/delete operations update both prev and next links
- Added _unlink() helper to centralise node removal logic
- Added display_reverse() to traverse from tail to head
- Updated display() to use <-> notation showing bidirectionality
- Updated main() demo with reverse-traversal section

https://claude.ai/code/session_01WEKurMzgxqt8f2N63gxNDk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because core list mutation logic (insert/delete/reverse) was rewritten to maintain `prev`/`tail` pointers, where pointer-update bugs could corrupt structure or sizing.
> 
> **Overview**
> Updates the Python linked list example from *singly* to **doubly linked** by adding `prev` pointers on `Node` and tracking a `tail` in `LinkedList` for O(1) `append`/`prepend`.
> 
> Refactors `insert`, `delete`, `delete_at_index`, and `reverse` to correctly maintain both `next`/`prev` links, centralizing removals in a new `_unlink()` helper. Adds `display_reverse()` and updates `display()` output formatting plus the README and `main()` demo to reflect reverse traversal and bidirectional representation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ec15b81d8d92c0d0a67dfc4e90078bb8bd80c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->